### PR TITLE
Fixed `class_declaration` typo in php_definition.py

### DIFF
--- a/blarify/code_hierarchy/languages/php_definitions.py
+++ b/blarify/code_hierarchy/languages/php_definitions.py
@@ -26,7 +26,7 @@ class PhpDefinitions(LanguageDefinitions):
 
     def should_create_node(node: Node) -> bool:
         return LanguageDefinitions._should_create_node_base_implementation(
-            node, ["class_delaration", "function_definition", "method_declaration"]
+            node, ["class_declaration", "function_definition", "method_declaration"]
         )
 
     def get_identifier_node(node: Node) -> Node:


### PR DESCRIPTION
A typo in the class_declaration rule of php_definition was causing the CLASS node to be omitted from the generated graph.